### PR TITLE
fix: memfs invalid drive letter

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -673,7 +673,7 @@
 #endif
 
 /*API for memory-mapped file access. */
-#define LV_USE_FS_MEMFS 1
+#define LV_USE_FS_MEMFS 0
 #if LV_USE_FS_MEMFS
     #define LV_FS_MEMFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
 #endif

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -673,9 +673,9 @@
 #endif
 
 /*API for memory-mapped file access. */
-#define LV_USE_FS_MEMFS 0
+#define LV_USE_FS_MEMFS 1
 #if LV_USE_FS_MEMFS
-    #define LV_FS_MEMFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_MEMFS_LETTER 'M'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
 #endif
 
 /*API for LittleFs. */


### PR DESCRIPTION
Fix docs build failure in LVGL `master` since https://github.com/lvgl/lvgl/pull/6367

https://github.com/lvgl/lvgl/actions/runs/10499498306/job/29086379497#step:10:218

Is memfs used in any of the examples somehow, despite the drive letter not being set?